### PR TITLE
Update openssl-gost-engine.spec

### DIFF
--- a/openssl-gost-engine.spec
+++ b/openssl-gost-engine.spec
@@ -8,7 +8,7 @@ License: OpenSSL
 URL: https://github.com/gost-engine/engine		
 Source0: %{name}-%{version}.tar.bz2	
 
-BuildRequires: cmake, openssl-devel	
+BuildRequires: cmake, openssl-devel	>= %{?rhel:1:}1.1
 Requires: openssl-libs	
 
 


### PR DESCRIPTION
Updated openssl-devel up to openssl-devel >= 1.1 to be in accordance to "Now this spec files are intended for recent releases of Fedora and, possible other RPM-based distros which do include OpenSSL 1.1 and above."